### PR TITLE
Fixed disabled displays causing detection issues

### DIFF
--- a/ddcci.cc
+++ b/ddcci.cc
@@ -101,7 +101,7 @@ populateHandlesMap()
                 monitorInfo.cbSize = sizeof(MONITORINFOEX);
                 GetMonitorInfo(monitor.handle, &monitorInfo);
 
-                for (size_t i = 0; i < monitor.physicalHandles.size(); i++) {
+                for (size_t i = 0; i <= monitor.physicalHandles.size(); i++) {
                     /**
                      * Re-create DISPLAY_DEVICE.DeviceName with
                      * MONITORINFOEX.szDevice and monitor index.
@@ -117,7 +117,7 @@ populateHandlesMap()
                     if (monitorName == deviceName) {
                         handles.insert(
                           { static_cast<std::string>(displayDev.DeviceID),
-                            monitor.physicalHandles[i] });
+                            monitor.physicalHandles[(monitor.physicalHandles.size() == 1 ? 0 : i)] });
 
                         break;
                     }

--- a/ddcci.cc
+++ b/ddcci.cc
@@ -54,7 +54,7 @@ void populateMonitorMap() {
         DWORD monitorIndex = 0;
         while (EnumDisplayDevices(displayAdapter.DeviceName, monitorIndex
               , &displayMonitor, EDD_GET_DEVICE_INTERFACE_NAME)) {
-            if (!(displayMonitor.StateFlags & DISPLAY_DEVICE_MIRRORING_DRIVER)) {
+            if (!(displayMonitor.StateFlags & DISPLAY_DEVICE_MIRRORING_DRIVER) && (displayMonitor.StateFlags & DISPLAY_DEVICE_ATTACHED_TO_DESKTOP) && (displayMonitor.StateFlags & DISPLAY_DEVICE_ACTIVE)) {
 
                 for (auto const& handle : monitorHandles) {
                     MONITORINFOEX monitorInfo;
@@ -82,7 +82,7 @@ void populateMonitorMap() {
                         break;
                     }
 
-                    for (DWORD i = 0; i < numPhysicalMonitors; i++) {
+                    for (DWORD i = 0; i <= numPhysicalMonitors; i++) {
                         std::string monitorName =
                                 static_cast<std::string>(monitorInfo.szDevice)
                               + "\\Monitor"
@@ -94,7 +94,7 @@ void populateMonitorMap() {
                         if (monitorName == deviceName) {
                             monitorMap.insert({
                                 static_cast<std::string>(displayMonitor.DeviceID)
-                              , physicalMonitors[i].hPhysicalMonitor
+                              , physicalMonitors[0].hPhysicalMonitor
                             });
                         }
                     }

--- a/ddcci.cc
+++ b/ddcci.cc
@@ -94,7 +94,7 @@ void populateMonitorMap() {
                         if (monitorName == deviceName) {
                             monitorMap.insert({
                                 static_cast<std::string>(displayMonitor.DeviceID)
-                              , physicalMonitors[0].hPhysicalMonitor
+                              , physicalMonitors[(numPhysicalMonitors == 1 ? 0 : i)].hPhysicalMonitor
                             });
                         }
                     }

--- a/ddcci.cc
+++ b/ddcci.cc
@@ -65,9 +65,9 @@ populateHandlesMap()
             throw std::runtime_error("Failed to get physical monitors.");
         }
 
-        for (DWORD i = 0; i < numPhysicalMonitors; i++) {
+        for (DWORD i = 0; i <= numPhysicalMonitors; i++) {
             monitor.physicalHandles.push_back(
-              physicalMonitors[i].hPhysicalMonitor);
+              physicalMonitors[(numPhysicalMonitors == 1 ? 0 : i)].hPhysicalMonitor);
         }
 
         delete[] physicalMonitors;
@@ -101,7 +101,7 @@ populateHandlesMap()
                 monitorInfo.cbSize = sizeof(MONITORINFOEX);
                 GetMonitorInfo(monitor.handle, &monitorInfo);
 
-                for (size_t i = 0; i <= monitor.physicalHandles.size(); i++) {
+                for (size_t i = 0; i < monitor.physicalHandles.size(); i++) {
                     /**
                      * Re-create DISPLAY_DEVICE.DeviceName with
                      * MONITORINFOEX.szDevice and monitor index.
@@ -117,7 +117,7 @@ populateHandlesMap()
                     if (monitorName == deviceName) {
                         handles.insert(
                           { static_cast<std::string>(displayDev.DeviceID),
-                            monitor.physicalHandles[(monitor.physicalHandles.size() == 1 ? 0 : i)] });
+                            monitor.physicalHandles[i] });
 
                         break;
                     }


### PR DESCRIPTION
Disabling a monitor in Windows can cause the monitor scanning to stop working. I haphazardly fixed it. I'm not sure that this doesn't cause bugs elsewhere, but I've been using it in a real app and nobody has reported issues.