### PR TITLE
Read maximum VCP value

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,15 @@ for (const monitor of ddcci.getMonitorList()) {
     * **`monitorName`**  
       &emsp;`String`. Name of monitor for which to query the brightness.
   * #### Return value
-    An `integer` between 0-100 representing the current brightness.
+    An `integer`, typically between 0-100, representing the current brightness.
+    
+* ### `getMaxBrightness(monitorName)`
+  Queries a monitor's maximum brightness level.
+  * #### Parameters
+    * **`monitorName`**  
+      &emsp;`String`. Name of monitor for which to query the brightness.
+  * #### Return value
+    An `integer`, typically between 0-100, representing the maximum brightness.
 
 * ### `setBrightness(monitorName, level)`
   Sets a monitor's brightness level.
@@ -48,7 +56,15 @@ for (const monitor of ddcci.getMonitorList()) {
     * **`monitorName`**  
       &emsp;`String`. Name of monitor for which to query the contrast.
   * #### Return value
-    An `integer` between 0-100 representing the current contrast.
+    An `integer`, typically between 0-100, representing the current contrast.
+    
+* ### `getMaxContrast(monitorName)`
+  Queries a monitor's maximum contrast level.
+  * #### Parameters
+    * **`monitorName`**  
+      &emsp;`String`. Name of monitor for which to query the contrast.
+  * #### Return value
+    An `integer`, typically between 0-100, representing the maximum contrast.
 
 * ### `setContrast(monitorName, level)`
   Sets a monitor's contrast level.
@@ -65,6 +81,8 @@ for (const monitor of ddcci.getMonitorList()) {
       &emsp;`String`. Name of monitor for which to query the VCP feature.
     * **`vcpCode`**  
       &emsp;`integer`. VCP code to query
+  * #### Return value
+    An `array` of two `integer` values in the format of `[currentValue, maxValue]`.
 
 * ### `_setVCP(monitorName, vcpCode, value)`
   Sets the value of a VCP code for a monitor.

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const ddcci = require("bindings")("ddcci");
 
 module.exports = {
     _getVCP: ddcci.getVCP
+  , _maxVCP: ddcci.maxVCP
   , _setVCP: ddcci.setVCP
   , _refresh: ddcci.refresh
   , getMonitorList: ddcci.getMonitorList
@@ -13,12 +14,20 @@ module.exports = {
         return ddcci.getVCP(monitor, 0x10);
     }
 
+  , getMaxBrightness (monitor) {
+        return ddcci.maxVCP(monitor, 0x10);
+    }
+
   , getContrast (monitor) {
         return ddcci.getVCP(monitor, 0x12);
     }
 
+  , getMaxContrast (monitor) {
+        return ddcci.maxVCP(monitor, 0x12);
+    }
+
   , setBrightness (monitor, level) {
-        if (level < 0 || level > 100) {
+        if (level < 0) {
             throw RangeError("Brightness level not within valid range");
         }
 
@@ -26,7 +35,7 @@ module.exports = {
     }
 
   , setContrast (monitor, level) {
-        if (level < 0 || level > 100) {
+        if (level < 0) {
             throw RangeError("Contrast level not within valid range");
         }
 

--- a/index.js
+++ b/index.js
@@ -4,26 +4,25 @@ const ddcci = require("bindings")("ddcci");
 
 module.exports = {
     _getVCP: ddcci.getVCP
-  , _maxVCP: ddcci.maxVCP
   , _setVCP: ddcci.setVCP
   , _refresh: ddcci.refresh
   , getMonitorList: ddcci.getMonitorList
 
 
   , getBrightness (monitor) {
-        return ddcci.getVCP(monitor, 0x10);
+        return ddcci.getVCP(monitor, 0x10)[0];
     }
 
   , getMaxBrightness (monitor) {
-        return ddcci.maxVCP(monitor, 0x10);
+        return ddcci.getVCP(monitor, 0x10)[1];
     }
 
   , getContrast (monitor) {
-        return ddcci.getVCP(monitor, 0x12);
+        return ddcci.getVCP(monitor, 0x12)[0];
     }
 
   , getMaxContrast (monitor) {
-        return ddcci.maxVCP(monitor, 0x12);
+        return ddcci.getVCP(monitor, 0x12)[1];
     }
 
   , setBrightness (monitor, level) {


### PR DESCRIPTION
Hello again!

As it turns out, not all displays max out their brightness/contrast at 100. Because of this, there needs to be a way to read the max value for a given VCP code and not restrict brightness/contrast to 0-100. This PR takes care of that by updating `getVCP`, along with adding `getMaxBrightness` and `getMaxContrast`.

`GetVCPFeatureAndVCPFeatureReply` already returns both the current and maximum values, so I've updated `getVCP` to return both in an array. The array is in the format `[currentValue, maxValue]`. Requesting them separately doubles execution time (ex. 250ms -> 500ms). However, I've split them up in the bindings for simplicity and backwards compatibility. Developers can use `_getVCP` directly to get both at once for better performance.

I've updated README.md to reflect these changes.